### PR TITLE
Update .gitmodules, remove branch version

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "agda-stdlib"]
 	path = agda-stdlib
 	url = https://github.com/agda/agda-stdlib.git
-        branch = v1.7-branch


### PR DESCRIPTION
The branch is called "v1.7-release" now so this does not work. 

"git checkout v1.7.1" in compile.sh should go to the right commit without needing a branch version indicator.